### PR TITLE
Fixing FacebookUser implementation of ResourceOwnerInterface

### DIFF
--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -136,7 +136,7 @@ class FacebookUser implements ResourceOwnerInterface
      *
      * @return array
      */
-    public function asArray()
+    public function toArray()
     {
         return $this->data;
     }


### PR DESCRIPTION
ResourceOwnerInterface declares for `toArray` not `asArray`. Thanks!