### PR TITLE
Change /me fields request to get more picture information

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -92,7 +92,7 @@ class Facebook extends AbstractProvider
     {
         $fields = implode(',', [
             'id', 'name', 'first_name', 'last_name',
-            'email', 'hometown', 'bio', 'picture.type(large){url}',
+            'email', 'hometown', 'bio', 'picture',
             'cover{source}', 'gender', 'locale', 'link',
         ]);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -92,7 +92,7 @@ class Facebook extends AbstractProvider
     {
         $fields = implode(',', [
             'id', 'name', 'first_name', 'last_name',
-            'email', 'hometown', 'bio', 'picture',
+            'email', 'hometown', 'bio', 'picture.type(large){url,is_silhouette}',
             'cover{source}', 'gender', 'locale', 'link',
         ]);
 

--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -20,6 +20,10 @@ class FacebookUser implements ResourceOwnerInterface
             $this->data['picture_url'] = $response['picture']['data']['url'];
         }
 
+        if (!empty($response['picture']['data']['is_silhouette'])) {
+            $this->data['is_silhouette'] = $response['picture']['data']['is_silhouette'];
+        }
+
         if (!empty($response['cover']['source'])) {
             $this->data['cover_photo_url'] = $response['cover']['source'];
         }
@@ -93,6 +97,17 @@ class FacebookUser implements ResourceOwnerInterface
     public function getBio()
     {
         return $this->getField('bio');
+    }
+
+    /**
+     * Returns if user has not defined a specific avatar
+     *
+     * @return boolean
+     */
+
+    public function isDefaultPicture()
+    {
+        return $this->getField('is_silhouette');
     }
 
     /**

--- a/tests/src/Provider/FacebookUserTest.php
+++ b/tests/src/Provider/FacebookUserTest.php
@@ -15,7 +15,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
     {
         $this->user = new FacebookUser([
             'id' => '4',
-            'picture' => ['data' => ['url' => 'foo.com/pic.jpg']],
+            'picture' => ['data' => ['is_silhouette' => true, 'url' => 'foo.com/pic.jpg']],
             'cover' => ['id' => '123', 'source' => 'foo.com/cover.jpg'],
             'first_name' => 'Mark',
             'last_name' => 'Zuck',
@@ -41,7 +41,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
 
         $expectedData = [
           'id' => '4',
-          'picture' => ['data' => ['url' => 'foo.com/pic.jpg']],
+          'picture' => ['data' => ['is_silhouette' => true, 'url' => 'foo.com/pic.jpg']],
           'cover' => ['id' => '123', 'source' => 'foo.com/cover.jpg'],
           'first_name' => 'Mark',
           'last_name' => 'Zuck',

--- a/tests/src/Provider/FacebookUserTest.php
+++ b/tests/src/Provider/FacebookUserTest.php
@@ -47,6 +47,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
           'last_name' => 'Zuck',
           'foo' => 'bar',
           'picture_url' => 'foo.com/pic.jpg',
+          'is_silhouette' => true,
           'cover_photo_url' => 'foo.com/cover.jpg',
         ];
 


### PR DESCRIPTION
The open graph API provides the is_silhouette information in picture['data'] to enable user default avatar checking. This is useful to not use FB's default avatar in case client uses a default avatar for its users.