### PR TITLE
Added timezone field to resource owner details

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -93,7 +93,7 @@ class Facebook extends AbstractProvider
         $fields = implode(',', [
             'id', 'name', 'first_name', 'last_name',
             'email', 'hometown', 'bio', 'picture.type(large){url,is_silhouette}',
-            'cover{source}', 'gender', 'locale', 'link',
+            'cover{source}', 'gender', 'locale', 'link', 'timezone'
         ]);
 
         return $this->getBaseGraphUrl().$this->graphApiVersion.'/me?fields='.$fields.'&access_token='.$token;

--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -161,6 +161,16 @@ class FacebookUser implements ResourceOwnerInterface
     }
 
     /**
+     * Returns the current timezone offset from UTC (from -24 to 24)
+     *
+     * @return float|null
+     */
+    public function getTimezone()
+    {
+        return $this->getField('timezone');
+    }
+
+    /**
      * Returns all the data obtained about the user.
      *
      * @return array

--- a/tests/src/Provider/FacebookUserTest.php
+++ b/tests/src/Provider/FacebookUserTest.php
@@ -20,6 +20,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
             'first_name' => 'Mark',
             'last_name' => 'Zuck',
             'foo' => 'bar',
+            'timezone' => '-8',
         ]);
     }
 
@@ -49,6 +50,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
           'picture_url' => 'foo.com/pic.jpg',
           'is_silhouette' => true,
           'cover_photo_url' => 'foo.com/cover.jpg',
+          'timezone' => '-8',
         ];
 
         $this->assertEquals($expectedData, $data);


### PR DESCRIPTION
According to https://developers.facebook.com/docs/graph-api/reference/user this is in the core scope and I think this attribute is quite useful.