### PR TITLE
Remove branch-alias attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,5 @@
         "psr-4": {
             "League\\OAuth2\\Client\\Test\\": "tests/src/"
         }
-    },
-    "branch-alias": {
-        "dev-master": "1.0.x-dev"
     }
 }


### PR DESCRIPTION
To fix #22. 
The attribute 'branch-alias' does not validate composer JSON schema and dev-master is not a real branch.
