### PR TITLE
Add the age range

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -93,7 +93,7 @@ class Facebook extends AbstractProvider
         $fields = implode(',', [
             'id', 'name', 'first_name', 'last_name',
             'email', 'hometown', 'bio', 'picture.type(large){url,is_silhouette}',
-            'cover{source}', 'gender', 'locale', 'link', 'timezone'
+            'cover{source}', 'gender', 'locale', 'link', 'timezone', 'age_range'
         ]);
         $appSecretProof = AppSecretProof::create($this->clientSecret, $token->getToken());
 

--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -170,17 +170,25 @@ class FacebookUser implements ResourceOwnerInterface
         return $this->getField('timezone');
     }
 
+    /**
+     * Returns the lower bound of the user's age range
+     *
+     * @return integer|null
+     */
     public function getMinAge()
     {
-        if (!empty($this->data['age_range'])
-            && !empty($this->data['age_range']['min']))
+        if (array_key_exists('min', $this->getField('age_range')))
             return $this->data['age_range']['min'];
     }
 
+    /**
+     * Returns the upper bound of the user's age range
+     *
+     * @return integer|null
+     */
     public function getMaxAge()
     {
-        if (!empty($this->data['age_range'])
-            && !empty($this->data['age_range']['max']))
+        if (array_key_exists('max', $this->getField('age_range')))
             return $this->data['age_range']['max'];
     }
 

--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -170,6 +170,20 @@ class FacebookUser implements ResourceOwnerInterface
         return $this->getField('timezone');
     }
 
+    public function getMinAge()
+    {
+        if (!empty($this->data['age_range'])
+            && !empty($this->data['age_range']['min']))
+            return $this->data['age_range']['min'];
+    }
+
+    public function getMaxAge()
+    {
+        if (!empty($this->data['age_range'])
+            && !empty($this->data['age_range']['max']))
+            return $this->data['age_range']['max'];
+    }
+
     /**
      * Returns all the data obtained about the user.
      *

--- a/src/Provider/FacebookUser.php
+++ b/src/Provider/FacebookUser.php
@@ -177,8 +177,10 @@ class FacebookUser implements ResourceOwnerInterface
      */
     public function getMinAge()
     {
-        if (array_key_exists('min', $this->getField('age_range')))
+        if (isset($this->data['age_range']['min'])) {
             return $this->data['age_range']['min'];
+        }
+        return null;
     }
 
     /**
@@ -188,8 +190,10 @@ class FacebookUser implements ResourceOwnerInterface
      */
     public function getMaxAge()
     {
-        if (array_key_exists('max', $this->getField('age_range')))
+        if (isset($this->data['age_range']['max'])) {
             return $this->data['age_range']['max'];
+        }
+        return null;
     }
 
     /**

--- a/tests/src/Provider/FacebookUserTest.php
+++ b/tests/src/Provider/FacebookUserTest.php
@@ -21,7 +21,14 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
             'last_name' => 'Zuck',
             'foo' => 'bar',
             'timezone' => '-8',
+            'age_range' => ['min' => 21],
         ]);
+    }
+
+    public function testMinAndMaxAgeReturnAgeOrNull()
+    {
+        $this->assertEquals(21, $this->user->getMinAge());
+        $this->assertNull($this->user->getMaxAge());
     }
 
     public function testGettersReturnNullWhenNoKeyExists()
@@ -51,6 +58,7 @@ class FacebookUserTest extends \PHPUnit_Framework_TestCase
           'is_silhouette' => true,
           'cover_photo_url' => 'foo.com/cover.jpg',
           'timezone' => '-8',
+          'age_range' => ['min' => 21],
         ];
 
         $this->assertEquals($expectedData, $data);


### PR DESCRIPTION
Hi,

I added the age_range to the fields.
As you can see in [facebook's documentation](https://developers.facebook.com/docs/facebook-login/permissions#reference-public_profile) the age_range is part of the _public_profile_ permission.
This way we can use all the fields that are available through the _public_profile_ permission which is the default one.