### PR TITLE
Added option to allow display type

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -43,7 +43,7 @@ class Facebook extends AbstractProvider
      * @const string
      */
     const GRAPH_API_VERSION_REGEX = '~^v\d+\.\d+$~';
-    
+
     /**
      * The Graph API version to use for requests.
      *
@@ -57,6 +57,15 @@ class Facebook extends AbstractProvider
      * @var boolean
      */
     private $enableBetaMode = false;
+
+    /**
+     * The display type to use the the authorization dialoge. By default (and not given) this is 'page'.
+     *
+     * Available options are: 'async', 'iframe', 'page', 'popup', 'touch' and 'wap'.
+     *
+     * @var string
+     */
+    private $displayType = 'page';
 
     /**
      * @param array $options
@@ -80,6 +89,15 @@ class Facebook extends AbstractProvider
 
         if (!empty($options['enableBetaTier']) && $options['enableBetaTier'] === true) {
             $this->enableBetaMode = true;
+        }
+
+        if (isset($options['display'])) {
+            if (!in_array($options['display'], ['async', 'iframe', 'page', 'popup', 'touch', 'wap'], true)) {
+                $message = 'The "display" must be one of the following values: async, iframe, page, popup, touch, wap.';
+                throw new \InvalidArgumentException($message);
+            }
+
+            $this->displayType = $options['display'];
         }
     }
 
@@ -195,5 +213,16 @@ class Facebook extends AbstractProvider
     private function getBaseGraphUrl()
     {
         return $this->enableBetaMode ? static::BASE_GRAPH_URL_BETA : static::BASE_GRAPH_URL;
+    }
+
+    protected function getAuthorizationParameters(array $options)
+    {
+        $parameters = parent::getAuthorizationParameters($options);
+
+        if ($this->displayType !== 'page') {
+            $parameters['display'] = $this->displayType;
+        }
+
+        return $parameters;
     }
 }

--- a/tests/src/Provider/FacebookTest.php
+++ b/tests/src/Provider/FacebookTest.php
@@ -55,7 +55,70 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertArrayNotHasKey('display', $query);
         $this->assertNotNull($this->provider->getState());
+    }
+
+    public function testAuthorizationUrlWithDisplay()
+    {
+        $provider = new Facebook([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+            'graphApiVersion' => static::GRAPH_API_VERSION,
+            'display' => 'iframe'
+        ]);
+
+        $url = $provider->getAuthorizationUrl();
+        $uri = parse_url($url);
+        parse_str($uri['query'], $query);
+
+        $this->assertArrayHasKey('client_id', $query);
+        $this->assertArrayHasKey('redirect_uri', $query);
+        $this->assertArrayHasKey('state', $query);
+        $this->assertArrayHasKey('scope', $query);
+        $this->assertArrayHasKey('response_type', $query);
+        $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertArrayHasKey('display', $query);
+        $this->assertNotNull($provider->getState());
+    }
+
+    public function testAuthorizationUrlWithDisplayDefault()
+    {
+        $provider = new Facebook([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+            'graphApiVersion' => static::GRAPH_API_VERSION,
+            'display' => 'page'
+        ]);
+
+        $url = $provider->getAuthorizationUrl();
+        $uri = parse_url($url);
+        parse_str($uri['query'], $query);
+
+        $this->assertArrayHasKey('client_id', $query);
+        $this->assertArrayHasKey('redirect_uri', $query);
+        $this->assertArrayHasKey('state', $query);
+        $this->assertArrayHasKey('scope', $query);
+        $this->assertArrayHasKey('response_type', $query);
+        $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertArrayNotHasKey('display', $query);
+        $this->assertNotNull($provider->getState());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAuthorizationUrlWithDisplayBadType()
+    {
+        new Facebook([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+            'graphApiVersion' => static::GRAPH_API_VERSION,
+            'display' => 'foobar'
+        ]);
     }
 
     public function testGetBaseAccessTokenUrl()


### PR DESCRIPTION
We want to show the oauth dialogue in a popup, but the default authorization page complains that the popup is too small. It is suggesting to change the display to `popup` to fix this. However, I do not think this is possible in the current state of this package.

So with this PR I would like to add the option to set the display field.

See https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow (section "For Windows 8 Apps") for more information.

Let me know if you agree to add this feature and if there is anything I need to change to get this approved.