### PR TITLE
Improve typehint for getResourceOwner

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -7,6 +7,9 @@ use League\OAuth2\Client\Provider\Exception\FacebookProviderException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @method FacebookUser getResourceOwner(AccessToken $token)
+ */
 class Facebook extends AbstractProvider
 {
     /**


### PR DESCRIPTION
It's easier to specify here instead of every place where method is used