### PR TITLE
Remove 'cover{source}' from default fields

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -103,7 +103,7 @@ class Facebook extends AbstractProvider
         $fields = [
             'id', 'name', 'first_name', 'last_name',
             'email', 'hometown', 'picture.type(large){url,is_silhouette}',
-            'cover{source}', 'gender', 'locale', 'link', 'timezone', 'age_range'
+            'gender', 'locale', 'link', 'timezone', 'age_range'
         ];
 
         // backwards compatibility less than 2.8


### PR DESCRIPTION
The default scopes `'public_profile', 'email'` doesn't grant the right to fetch: `cover{source}`.

There are no scopes that allows you to fetch this field anymore which makes this library not work.

Cheers, thanks for your work,