### PR TITLE
[BUGFIX] Changed FacebookProviderException to extend IdentityProvider…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.1 - March 6, 2023
+
+- Changed class FacebookProviderException to extend IdentityProviderException
+
 ## 2.2.0 - Febuary 24, 2022
 
 - Make URL getters protected to allow extension, #74 by @mlncn

--- a/src/Provider/Exception/FacebookProviderException.php
+++ b/src/Provider/Exception/FacebookProviderException.php
@@ -4,6 +4,6 @@ namespace League\OAuth2\Client\Provider\Exception;
 
 use Exception;
 
-class FacebookProviderException extends Exception
+class FacebookProviderException extends IdentityProviderException
 {
 }


### PR DESCRIPTION
This way, a FacebookProviderException is also a IdentityProviderException - as it is also done in other implementations of oauth2-github, ... 